### PR TITLE
Show logs in error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             swift: "5.7"
 
     steps:
-      - uses: fwal/setup-swift@v1.14.0
+      - uses: swift-actions/setup-swift@v1
         with:
           swift-version: ${{ matrix.swift }}
       - run: swift --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,19 @@ jobs:
             swift: "5.5"
           - os: macos-11.0
             swift: "5.6"
+          - os: macos-11.0
+            swift: "5.7"
           # difficult to get a macos 12 runner on GitHub
           # - os: macos-12.0
           #   swift: "5.5"
           # - os: macos-12.0
           #   swift: "5.6"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             swift: "5.5"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             swift: "5.6"
+          - os: ubuntu-latest
+            swift: "5.7"
 
     steps:
       - uses: fwal/setup-swift@v1.14.0

--- a/Sources/Sh/Errors.swift
+++ b/Sources/Sh/Errors.swift
@@ -2,11 +2,27 @@ import Foundation
 
 public enum Errors: Error, LocalizedError {
   case unexpectedNilDataError
-  
+  case errorWithLogInfo(String, underlyingError: Error)
+  case openingLogError(Error, underlyingError: Error)
+
   public var errorDescription: String? {
     switch self {
     case .unexpectedNilDataError:
       return "Expected data, but there wasn't any"
+    case .errorWithLogInfo(let logInfo, underlyingError: let underlyingError):
+      return """
+        An error occurred: \(underlyingError.localizedDescription)
+
+        Here is the contents of the log file:
+
+        \(logInfo)
+        """
+    case .openingLogError(let error, underlyingError: let underlyingError):
+      return """
+        An error occurred: \(underlyingError.localizedDescription)
+
+        Also, an error occurred while attempting to open the log file: \(error.localizedDescription)
+        """
     }
   }
 }

--- a/Sources/Sh/sh.swift
+++ b/Sources/Sh/sh.swift
@@ -99,9 +99,17 @@ public func sh(_ sink: Sink,
     } catch {
       let underlyingError = error
 
-      
-      let log = try! String(contentsOfFile: path).trimmingCharacters(in: .whitespacesAndNewlines)
-      throw Errors.errorWithLogInfo(log, underlyingError: underlyingError)
+      let logResult = Result {
+        try String(contentsOfFile: path)
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+
+      switch logResult {
+      case .success(let success):
+        throw Errors.errorWithLogInfo(success, underlyingError: underlyingError)
+      case .failure(let failure):
+        throw Errors.openingLogError(failure, underlyingError: underlyingError)
+      }
     }
   }
 }

--- a/Sources/Sh/sh.swift
+++ b/Sources/Sh/sh.swift
@@ -83,13 +83,27 @@ public func sh(_ sink: Sink,
   switch sink {
   case .terminal:
     announce("Running `\(cmd)`")
-  case .file(let path):
-    announce("Running `\(cmd)`, logging to `\(path.blue)`")
+    
+    try shq(sink, cmd, environment: environment, workingDirectory: workingDirectory)
+    
   case .null:
     announce("Running `\(cmd)`, discarding output")
-  }
+    
+    try shq(sink, cmd, environment: environment, workingDirectory: workingDirectory)
+    
+    
+  case .file(let path):
+    announce("Running `\(cmd)`, logging to `\(path.blue)`")
+    do {
+      try shq(sink, cmd, environment: environment, workingDirectory: workingDirectory)
+    } catch {
+      let underlyingError = error
 
-  try shq(sink, cmd, environment: environment, workingDirectory: workingDirectory)
+      
+      let log = try! String(contentsOfFile: path).trimmingCharacters(in: .whitespacesAndNewlines)
+      throw Errors.errorWithLogInfo(log, underlyingError: underlyingError)
+    }
+  }
 }
 
 /// `Async`/`await` version

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Sh
+
+final class LogFileTests: XCTestCase {
+
+  func testSimple() throws {
+
+    do {
+      try sh(.file("/tmp/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
+    } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
+      XCTAssertEqual(logInfo, "/bin/sh: /unknown/path/name: No such file or directory")
+
+      let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
+
+      XCTAssertEqual(terminationError.status, 1)
+      XCTAssertEqual(terminationError.reason, "`regular exit`")
+    } catch {
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
+    }
+  }
+}

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -9,11 +9,12 @@ final class LogFileTests: XCTestCase {
       try sh(.file("/tmp/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
-      XCTAssertEqual(logInfo, "/bin/sh: /unknown/path/name: No such file or directory")
+
+      XCTAssertTrue(logInfo.contains("/unknown/path/name")
 
       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
 
-      XCTAssertEqual(terminationError.status, 1)
+      XCTAssertNotEqual(terminationError.status, 0)
       XCTAssertEqual(terminationError.reason, "`regular exit`")
     } catch {
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -19,4 +19,21 @@ final class LogFileTests: XCTestCase {
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
     }
   }
+
+  func testUnwritableLogfile() throws {
+    XCTAssertThrowsError(
+      try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+    ) { error in
+
+      switch error {
+      case Errors.openingLogError(let logError, underlyingError: let underlyingError):
+        XCTAssertEqual(logError.localizedDescription, "The file “sh-test.log” couldn’t be opened because there is no such file.")
+
+        XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
+
+      default:
+        XCTFail("Expected an opening log error, but got \(error)")
+      }
+    }
+  }
 }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -25,10 +25,15 @@ final class LogFileTests: XCTestCase {
     do {
       try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
+
+      #if os(Linux)
+      XCTAssertEqual(logError.localizedDescription, "The operation could not be completed. No such file or directory")
+      #else
       XCTAssertEqual(logError.localizedDescription, "The file “sh-test.log” couldn’t be opened because there is no such file.")
+      #endif
 
       XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
-      
+
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")
     }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -10,7 +10,7 @@ final class LogFileTests: XCTestCase {
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 
-      XCTAssertTrue(logInfo.contains("/unknown/path/name")
+      XCTAssertTrue(logInfo.contains("/unknown/path/name"))
 
       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
 
@@ -22,19 +22,15 @@ final class LogFileTests: XCTestCase {
   }
 
   func testUnwritableLogfile() throws {
-    XCTAssertThrowsError(
+    do {
       try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
-    ) { error in
+    } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
+      XCTAssertEqual(logError.localizedDescription, "The file “sh-test.log” couldn’t be opened because there is no such file.")
 
-      switch error {
-      case Errors.openingLogError(let logError, underlyingError: let underlyingError):
-        XCTAssertEqual(logError.localizedDescription, "The file “sh-test.log” couldn’t be opened because there is no such file.")
-
-        XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
-
-      default:
-        XCTFail("Expected an opening log error, but got \(error)")
-      }
+      XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
+      
+    } catch {
+      XCTFail("Expected an opening log error, but got \(error)")
     }
   }
 }


### PR DESCRIPTION
When using the `Sink.file`, and an error happens, the user must then open their log file themselves. What if we included the logs in the error? This PR implements this.