### PR TITLE
Cleanup file handle once reading is complete

### DIFF
--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -31,7 +31,12 @@ class PipeBuffer {
     queue.sync {
       let value = self.buffer
       block(value)
+      cleanup()
     }
+  }
+
+  func cleanup() {
+    pipe.fileHandleForReading.readabilityHandler = nil
   }
   
   var unsafeValue: Data {


### PR DESCRIPTION
Fixes #4

This addresses a major usability issue that causes significant resource usage for each command run.