### PR TITLE
S3e15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
-            swift: "5.7"
-          - os: macos-13
-            swift: "5.7"
-          - os: ubuntu-latest
-            swift: "5.7"
           - os: macos-13
             swift: "5.8"
           - os: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         include:
           - os: macos-13
             swift: "5.8"
-          - os: macos-12
-            swift: "5.8"
           - os: ubuntu-latest
             swift: "5.8"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,16 @@ jobs:
         include:
           - os: macos-12
             swift: "5.7"
+          - os: macos-13
+            swift: "5.7"
           - os: ubuntu-latest
             swift: "5.7"
+          - os: macos-13
+            swift: "5.8"
+          - os: macos-12
+            swift: "5.8"
+          - os: ubuntu-latest
+            swift: "5.8"
 
     steps:
       - uses: swift-actions/setup-swift@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ jobs:
         run: swift test
 
       - name: build for release
-        run: swift build -c release
+        run: rm -fr .build && swift build -c release
 
       - name: test 2
-        run: swift test
+        run: rm -fr .build && swift test
 
       - name: test 3
-        run: swift test
+        run: rm -fr .build && swift test
 
       - name: test 4
-        run: swift test
+        run: rm -fr .build && swift test

--- a/Fixtures/SwiftProjectWithFailingTests/Package.resolved
+++ b/Fixtures/SwiftProjectWithFailingTests/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Fixtures/SwiftProjectWithFailingTests/Package.resolved
+++ b/Fixtures/SwiftProjectWithFailingTests/Package.resolved
@@ -8,6 +8,33 @@
         "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
         "version" : "1.2.2"
       }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "revision" : "29d9c97e6310b87c4799268eaa2fc76164b2dbd8",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "ae848811f9b1b0e79d429e1df8fa60eac5587d81",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown",
+      "state" : {
+        "revision" : "68b2fed9fb12fb71ac81e537f08bed430b189e35",
+        "version" : "0.2.0"
+      }
     }
   ],
   "version" : 2

--- a/Fixtures/SwiftProjectWithFailingTests/Package.swift
+++ b/Fixtures/SwiftProjectWithFailingTests/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 
 import PackageDescription
 

--- a/Fixtures/SwiftProjectWithFailingTests/Package.swift
+++ b/Fixtures/SwiftProjectWithFailingTests/Package.swift
@@ -11,7 +11,12 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-argument-parser",
       from: "1.2.0"),
-
+    .package(
+      url: "https://github.com/apple/swift-markdown",
+      from: "0.2.0"),
+    .package(
+      url: "https://github.com/apple/swift-http-types",
+      from: "0.1.0"),
   ],
   targets: [
     .target(

--- a/Fixtures/SwiftProjectWithFailingTests/Package.swift
+++ b/Fixtures/SwiftProjectWithFailingTests/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.7
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftProjectWithFailingTests",
+  platforms: [
+    .macOS(.v12),
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/apple/swift-argument-parser",
+      from: "1.2.0"),
+
+  ],
+  targets: [
+    .target(
+      name: "SomeLibrary",
+      dependencies: []),
+    .testTarget(
+      name: "SomeLibraryTests",
+      dependencies: ["SomeLibrary"]),
+  ])

--- a/Fixtures/SwiftProjectWithFailingTests/Sources/SomeLibrary/Library.swift
+++ b/Fixtures/SwiftProjectWithFailingTests/Sources/SomeLibrary/Library.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public struct Library {
+  public let name: String
+  public init(name: String) {
+    self.name = name
+  }
+}

--- a/Fixtures/SwiftProjectWithFailingTests/Tests/SomeLibraryTests/SomeLibraryTests.swift
+++ b/Fixtures/SwiftProjectWithFailingTests/Tests/SomeLibraryTests/SomeLibraryTests.swift
@@ -1,0 +1,10 @@
+@testable import SomeLibrary
+import XCTest
+import Foundation
+
+final class SomeLibraryTests: XCTestCase {
+
+  func testIntentionallyFailingTest() {
+    XCTAssertEqual(Library(name: "Some name").name, "Wrong name")
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,3 +17,11 @@ let package = Package(
     .target(name: "Sh", dependencies: ["Rainbow"]),
     .testTarget(name: "ShTests", dependencies: ["Sh"]),
   ])
+
+
+#if os(Linux)
+package.dependencies.append(
+  .package(url: "https://github.com/apple/swift-system", from: "1.0.0")
+)
+package.targets.first!.dependencies.append(.product(name: "SystemPackage", package: "swift-system"))
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "Sh",
   platforms: [
-    .macOS(.v12),
+    .macOS(.v13),
   ],
   products: [
     .library(name: "Sh", targets: ["Sh"]),

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Here is a simple example, where we ask the shell for the date, formatted as seco
     
 Supposing this was in a script named `Date`, a shell session might look like this:
 
-     % swish Date
-    [Sh] Running `swift package --package-path Swish dump-package`, decoding `SwiftPackageDump`
-    [Swish] Running target named `Date`
-    [Sh] Running `swift run --package-path Swish Date `
+     % spx Date
+    [Sh] Running `swift package --package-path SPX dump-package`, decoding `SwiftPackageDump`
+    [SPX] Running target named `Date`
+    [Sh] Running `swift run --package-path SPX Date `
     Fetching https://github.com/FullQueueDeveloper/Sh.git from cache
     Fetched https://github.com/FullQueueDeveloper/Sh.git (0.24s)
     Computing version for https://github.com/FullQueueDeveloper/Sh.git
@@ -60,10 +60,10 @@ Supposing this was in a script named `Date`, a shell session might look like thi
     
 And if all the package have resolved, a shell session might look like this:
 
-     % swish Date
-    [Sh] Running `swift package --package-path Swish dump-package`, decoding `SwiftPackageDump`
-    [Swish] Running target named `Date`
-    [Sh] Running `swift run --package-path Swish Date `
+     % spx Date
+    [Sh] Running `swift package --package-path SPX dump-package`, decoding `SwiftPackageDump`
+    [SPX] Running target named `Date`
+    [Sh] Running `swift run --package-path SPX Date `
     Building for debugging...
     Build complete! (0.08s)
     [Sh] Running `date +%s`, decoding `Double`

--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ This package by itself does not try to provide a domain specific language for va
 - [ShXcrun](https://github.com/FullQueueDeveloper/ShXcrun) for a Sh wrapper around tools shipped with Xcode such as `xcodebuild` and `altool`.
 - [ShGit](https://github.com/FullQueueDeveloper/ShGit) for a Sh wrapper around Git.
 - [Sh1Password](https://github.com/FullQueueDeveloper/Sh1Password) for a Sh wrapper around 1Password's CLI version 2.
+
+## About the author
+
+Follow Full Queue Developer on [Twitch](https://twitch.tv/FullQueueDeveloper) for live coding, [Discord](http://FullQueueDeveloper.com/discord) for hanging out, and [Mastodon](https://mastodon.online/@FullQueueDeveloper) for updates. If this library helps you out, you can [sponsor on GitHub](https://github.com/sponsors/FullQueueDeveloper).

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -23,9 +23,9 @@ class PipeBuffer {
     )
 
     self.pipe.fileHandleForReading.readabilityHandler = { handler in
-
+      self.semaphore.enter()
       self.queue.async {
-        self.semaphore.enter()
+
         let data = try! handler.readToEnd()
         self.buffer.append(contentsOf: data ?? Data())
         self.semaphore.leave()

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -8,6 +8,8 @@ class PipeBuffer {
   let pipe = Pipe()
   private var buffer: Data = .init()
   private let queue: DispatchQueue
+
+  private let semaphore = DispatchGroup()
   
   convenience init(id: StreamID, qos: DispatchQoS.QoSClass = .userInitiated) {
     self.init(label: id.rawValue, qos: qos)
@@ -21,16 +23,21 @@ class PipeBuffer {
     )
 
     self.pipe.fileHandleForReading.readabilityHandler = { handler in
+
       self.queue.async {
+        self.semaphore.enter()
         let data = try! handler.readToEnd()
         self.buffer.append(contentsOf: data ?? Data())
+        self.semaphore.leave()
       }
     }
   }
 
   func closeReturningData() -> Data {
+
     let data = queue.sync {
-      self.buffer
+      self.semaphore.wait()
+      return self.buffer
     }
 
     self.pipe.fileHandleForReading.readabilityHandler = nil

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -5,23 +5,13 @@ class PipeBuffer {
     case stdOut, stdErr
   }
   
-  let pipe = Pipe()
+  internal let pipe = Pipe()
   private var buffer: Data = .init()
-  private let queue: DispatchQueue
-
   private let semaphore = DispatchGroup()
-  private let lock = NSLock()
-  
-  convenience init(id: StreamID, qos: DispatchQoS.QoSClass = .userInitiated) {
-    self.init(label: id.rawValue, qos: qos)
-  }
-  
-  init(label: String, qos: DispatchQoS.QoSClass = .userInitiated) {
 
-    self.queue = DispatchQueue(
-      label: label,
-      target: DispatchQueue.global(qos: qos)
-    )
+  let id: StreamID
+  init(id: StreamID) {
+    self.id = id
 
     self.pipe.fileHandleForReading.readabilityHandler = { handler in
       self.semaphore.enter()
@@ -32,20 +22,12 @@ class PipeBuffer {
   }
 
   func closeReturningData() -> Data {
-    let result = self.semaphore.wait(timeout: .now() + 1.1)
-    switch result {
-    case .success:
-      print("SUCCESS")
-    case .timedOut:
-      print("TIME OUT")
-    }
+    self.semaphore.wait()
 
-    return queue.sync {
-      self.semaphore.wait()
-      let data = self.buffer
-      self.buffer = Data()
-      self.pipe.fileHandleForReading.readabilityHandler = nil
-      return data
-    }
+    self.semaphore.wait()
+    let data = self.buffer
+    self.buffer = Data()
+    self.pipe.fileHandleForReading.readabilityHandler = nil
+    return data
   }
 }

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -29,7 +29,6 @@ class PipeBuffer {
 
     let data = self.buffer + remainingData
     self.buffer = Data()
-    self.pipe.fileHandleForReading.readabilityHandler = nil
     return data
   }
 }

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -21,10 +21,14 @@ class PipeBuffer {
     )
 
     self.pipe.fileHandleForReading.readabilityHandler = { handler in
-      self.queue.async {
-        let nextData = handler.availableData
-        self.buffer.append(contentsOf: nextData)
-      }
+      let data = handler.availableData
+      self.append(data: data)
+    }
+  }
+
+  func append(data: Data) {
+    self.queue.async {
+      self.buffer.append(contentsOf: data)
     }
   }
 

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -29,13 +29,13 @@ class PipeBuffer {
   }
 
   func closeReturningData() -> Data {
-    let value = queue.sync {
+    let data = queue.sync {
       self.buffer
     }
 
     self.pipe.fileHandleForReading.readabilityHandler = nil
     self.buffer = Data()
 
-    return value
+    return data
   }
 }

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -22,21 +22,18 @@ class PipeBuffer {
   }
   
   func append(_ more: Data) {
-    queue.async {
+    queue.sync {
       self.buffer.append(contentsOf: more)
     }
   }
   
-  func yieldValue(block: @escaping (Data) -> Void) {
+  func yieldValueAndClose(block: @escaping (Data) -> Void) {
     queue.sync {
       let value = self.buffer
       block(value)
-      cleanup()
+      pipe.fileHandleForReading.readabilityHandler = nil
+      buffer = Data()
     }
-  }
-
-  func cleanup() {
-    pipe.fileHandleForReading.readabilityHandler = nil
   }
   
   var unsafeValue: Data {

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -21,25 +21,19 @@ class PipeBuffer {
     )
 
     self.pipe.fileHandleForReading.readabilityHandler = { handler in
-      let nextData = handler.availableData
-      self.append(nextData)
+      self.queue.async {
+        let nextData = handler.availableData
+        self.buffer.append(contentsOf: nextData)
+      }
     }
   }
-  
-  func append(_ more: Data) {
-    queue.async {
-      self.buffer.append(contentsOf: more)
-    }
-  }
-  
+
   func closeReturningData() -> Data {
-
-    self.pipe.fileHandleForReading.readabilityHandler = nil
-
     let value = queue.sync {
       self.buffer
     }
 
+    self.pipe.fileHandleForReading.readabilityHandler = nil
     self.buffer = Data()
 
     return value

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -22,7 +22,7 @@ class PipeBuffer {
 
     pipe.fileHandleForReading.readabilityHandler = { handler in
       let nextData = handler.availableData
-      self.buffer.append(nextData)
+      self.append(nextData)
     }
   }
   
@@ -32,20 +32,15 @@ class PipeBuffer {
     }
   }
   
-  func yieldValueAndClose() -> Data {
+  func closeReturningData() -> Data {
 
     let value = queue.sync {
       self.buffer
     }
+    
     self.buffer = Data()
     self.pipe.fileHandleForReading.readabilityHandler = nil
-//    self.pipe.fileHandleForWriting.writeabilityHandler = nil
 
     return value
-
-  }
-  
-  var unsafeValue: Data {
-    buffer
   }
 }

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -20,7 +20,7 @@ class PipeBuffer {
       target: DispatchQueue.global(qos: qos)
     )
 
-    pipe.fileHandleForReading.readabilityHandler = { handler in
+    self.pipe.fileHandleForReading.readabilityHandler = { handler in
       let nextData = handler.availableData
       self.append(nextData)
     }
@@ -34,12 +34,13 @@ class PipeBuffer {
   
   func closeReturningData() -> Data {
 
+    self.pipe.fileHandleForReading.readabilityHandler = nil
+
     let value = queue.sync {
       self.buffer
     }
-    
+
     self.buffer = Data()
-    self.pipe.fileHandleForReading.readabilityHandler = nil
 
     return value
   }

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -24,7 +24,10 @@ class PipeBuffer {
   func closeReturningData() -> Data {
     self.semaphore.wait()
 
-    let data = self.buffer
+    self.pipe.fileHandleForReading.readabilityHandler = nil
+    let remainingData = try! self.pipe.fileHandleForReading.readToEnd() ?? Data()
+
+    let data = self.buffer + remainingData
     self.buffer = Data()
     self.pipe.fileHandleForReading.readabilityHandler = nil
     return data

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -24,7 +24,6 @@ class PipeBuffer {
   func closeReturningData() -> Data {
     self.semaphore.wait()
 
-    self.semaphore.wait()
     let data = self.buffer
     self.buffer = Data()
     self.pipe.fileHandleForReading.readabilityHandler = nil

--- a/Sources/Sh/Data/PipeBuffer.swift
+++ b/Sources/Sh/Data/PipeBuffer.swift
@@ -36,7 +36,7 @@ class PipeBuffer {
   func closeReturningData() -> Data {
 
     let data = queue.sync {
-      self.semaphore.wait()
+      _ = self.semaphore.wait(timeout: .now() + 2)
       return self.buffer
     }
 

--- a/Sources/Sh/Errors.swift
+++ b/Sources/Sh/Errors.swift
@@ -8,9 +8,7 @@ public enum Errors: Error, LocalizedError {
     switch self {
     case .errorWithLogInfo(let logInfo, underlyingError: let underlyingError):
       return """
-        An error occurred: \(underlyingError.localizedDescription)
-
-        Here is the contents of the log file:
+        An error occurred: \(underlyingError.localizedDescription). Here is the contents of the log file:
 
         \(logInfo)
         """

--- a/Sources/Sh/Errors.swift
+++ b/Sources/Sh/Errors.swift
@@ -5,13 +5,18 @@ public enum Errors: Error, LocalizedError {
   case openingLogError(Error, underlyingError: Error)
 
   public var errorDescription: String? {
+    description
+  }
+
+  public var description: String {
     switch self {
     case .errorWithLogInfo(let logInfo, underlyingError: let underlyingError):
       return """
         An error occurred: \(underlyingError.localizedDescription). Here is the contents of the log file:
 
-        \(logInfo)
-        """
+        
+        """ + logInfo
+
     case .openingLogError(let error, underlyingError: let underlyingError):
       return """
         An error occurred: \(underlyingError.localizedDescription)

--- a/Sources/Sh/Process/Process.runRedirectingAllOutput.swift
+++ b/Sources/Sh/Process/Process.runRedirectingAllOutput.swift
@@ -1,4 +1,5 @@
 import Foundation
+import System
 
 extension Process {
   
@@ -60,6 +61,8 @@ extension Process {
   }
   
   private func createFile(atPath path: String) throws -> FileHandle {
+    let directories = FilePath(path).lexicallyNormalized().removingLastComponent()
+    try FileManager.default.createDirectory(atPath: directories.string, withIntermediateDirectories: true)
     guard FileManager.default.createFile(atPath: path, contents: Data()) else {
       struct CouldNotCreateFile: Error {
         let path: String

--- a/Sources/Sh/Process/Process.runRedirectingAllOutput.swift
+++ b/Sources/Sh/Process/Process.runRedirectingAllOutput.swift
@@ -1,5 +1,10 @@
 import Foundation
+
+#if os(Linux)
+import SystemPackage
+#else
 import System
+#endif
 
 extension Process {
   

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -2,9 +2,11 @@ import Foundation
 
 extension Process {
   
-  public typealias AllOutput = (stdOut: Data,
-                                stdErr: Data,
-                                terminationError: TerminationError?)
+  public struct AllOutput {
+    public let stdOut: Data,
+        stdErr: Data,
+        terminationError: TerminationError?
+  }
   
   public func runReturningAllOutput() throws -> AllOutput {
         
@@ -17,7 +19,7 @@ extension Process {
     try self.run()
     self.waitUntilExit()
 
-    return (stdOut: stdOut.closeReturningData(),
+    return AllOutput(stdOut: stdOut.closeReturningData(),
             stdErr: stdErr.closeReturningData(),
             terminationError: terminationError)
   }
@@ -39,9 +41,9 @@ extension Process {
         let stdOutData = stdOut.closeReturningData()
 
 
-        continuation.resume(returning: (stdOutData,
-                                        stdErrData,
-                                        maybeTerminationError))
+        continuation.resume(returning: AllOutput(stdOut: stdOutData,
+                                                 stdErr: stdErrData,
+                                                 terminationError: maybeTerminationError))
       }
       
       do {

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -19,9 +19,10 @@ extension Process {
     try self.run()
     self.waitUntilExit()
 
-    return AllOutput(stdOut: try stdOut.closeReturningData(),
-            stdErr: try stdErr.closeReturningData(),
-            terminationError: terminationError)
+    return AllOutput(
+      stdOut: stdOut.closeReturningData(),
+      stdErr: stdErr.closeReturningData(),
+      terminationError: terminationError)
   }
   
   public func runReturningAllOutput() async throws -> AllOutput {
@@ -35,15 +36,10 @@ extension Process {
     return try await withCheckedThrowingContinuation  { (continuation: CheckedContinuation<AllOutput, Error>) in
       
       self.terminationHandler = { process in
-        let maybeTerminationError = process.terminationError
-        
-        let stdErrData = try! stdErr.closeReturningData()
-        let stdOutData = try! stdOut.closeReturningData()
-
-
-        continuation.resume(returning: AllOutput(stdOut: stdOutData,
-                                                 stdErr: stdErrData,
-                                                 terminationError: maybeTerminationError))
+        continuation.resume(returning: AllOutput(
+          stdOut: stdOut.closeReturningData(),
+          stdErr: stdErr.closeReturningData(),
+          terminationError: process.terminationError))
       }
       
       do {

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -35,13 +35,13 @@ extension Process {
       self.terminationHandler = { process in
         let maybeTerminationError = process.terminationError
         
-        stdErr.yieldValueAndClose { stdErrData in
-          stdOut.yieldValueAndClose { stdOutData in
-            continuation.resume(returning: (stdOutData,
-                                            stdErrData,
-                                            maybeTerminationError))
-          }
-        }
+        let stdErrData = stdErr.yieldValueAndClose()
+        let stdOutData = stdOut.yieldValueAndClose()
+
+
+        continuation.resume(returning: (stdOutData,
+                                        stdErrData,
+                                        maybeTerminationError))
       }
       
       do {

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -19,8 +19,8 @@ extension Process {
     try self.run()
     self.waitUntilExit()
 
-    return AllOutput(stdOut: stdOut.closeReturningData(),
-            stdErr: stdErr.closeReturningData(),
+    return AllOutput(stdOut: try stdOut.closeReturningData(),
+            stdErr: try stdErr.closeReturningData(),
             terminationError: terminationError)
   }
   
@@ -37,8 +37,8 @@ extension Process {
       self.terminationHandler = { process in
         let maybeTerminationError = process.terminationError
         
-        let stdErrData = stdErr.closeReturningData()
-        let stdOutData = stdOut.closeReturningData()
+        let stdErrData = try! stdErr.closeReturningData()
+        let stdOutData = try! stdOut.closeReturningData()
 
 
         continuation.resume(returning: AllOutput(stdOut: stdOutData,

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -16,7 +16,7 @@ extension Process {
     
     try self.run()
     self.waitUntilExit()
-    
+
     return (stdOut: stdOut.unsafeValue,
             stdErr: stdErr.unsafeValue,
             terminationError: terminationError)
@@ -35,8 +35,8 @@ extension Process {
       self.terminationHandler = { process in
         let maybeTerminationError = process.terminationError
         
-        stdErr.yieldValue { stdErrData in
-          stdOut.yieldValue { stdOutData in
+        stdErr.yieldValueAndClose { stdErrData in
+          stdOut.yieldValueAndClose { stdOutData in
             continuation.resume(returning: (stdOutData,
                                             stdErrData,
                                             maybeTerminationError))

--- a/Sources/Sh/Process/Process.runReturningAllOutput.swift
+++ b/Sources/Sh/Process/Process.runReturningAllOutput.swift
@@ -17,8 +17,8 @@ extension Process {
     try self.run()
     self.waitUntilExit()
 
-    return (stdOut: stdOut.unsafeValue,
-            stdErr: stdErr.unsafeValue,
+    return (stdOut: stdOut.closeReturningData(),
+            stdErr: stdErr.closeReturningData(),
             terminationError: terminationError)
   }
   
@@ -35,8 +35,8 @@ extension Process {
       self.terminationHandler = { process in
         let maybeTerminationError = process.terminationError
         
-        let stdErrData = stdErr.yieldValueAndClose()
-        let stdOutData = stdOut.yieldValueAndClose()
+        let stdErrData = stdErr.closeReturningData()
+        let stdOutData = stdOut.closeReturningData()
 
 
         continuation.resume(returning: (stdOutData,

--- a/Sources/Sh/Process/Process.runReturningData.swift
+++ b/Sources/Sh/Process/Process.runReturningData.swift
@@ -15,7 +15,7 @@ extension Process {
     if let terminationError = terminationError {
       throw terminationError
     } else {
-      return try stdOut.closeReturningData()
+      return stdOut.closeReturningData()
     }
   }
     
@@ -30,12 +30,8 @@ extension Process {
         if let terminationError = process.terminationError {
           continuation.resume(throwing: terminationError)
         } else {
-          do {
-            let data = try stdOut.closeReturningData()
-            continuation.resume(returning: data)
-          } catch {
-            continuation.resume(throwing: error)
-          }
+          let data = stdOut.closeReturningData()
+          continuation.resume(returning: data)
         }
       }
       

--- a/Sources/Sh/Process/Process.runReturningData.swift
+++ b/Sources/Sh/Process/Process.runReturningData.swift
@@ -15,7 +15,7 @@ extension Process {
     if let terminationError = terminationError {
       throw terminationError
     } else {
-      return stdOut.unsafeValue
+      return stdOut.closeReturningData()
     }
   }
     
@@ -30,7 +30,7 @@ extension Process {
         if let terminationError = process.terminationError {
           continuation.resume(throwing: terminationError)
         } else {
-          let data = stdOut.yieldValueAndClose()
+          let data = stdOut.closeReturningData()
           continuation.resume(returning: data)
         }
       }

--- a/Sources/Sh/Process/Process.runReturningData.swift
+++ b/Sources/Sh/Process/Process.runReturningData.swift
@@ -30,16 +30,15 @@ extension Process {
         if let terminationError = process.terminationError {
           continuation.resume(throwing: terminationError)
         } else {
-          stdOut.yieldValueAndClose { data in
-            continuation.resume(returning: data)
-          }
+          let data = stdOut.yieldValueAndClose()
+          continuation.resume(returning: data)
         }
       }
       
       do {
         try self.run()
       } catch {
-        continuation.resume(with: .failure(error))
+        continuation.resume(throwing: error)
       }
     }
   }

--- a/Sources/Sh/Process/Process.runReturningData.swift
+++ b/Sources/Sh/Process/Process.runReturningData.swift
@@ -30,7 +30,7 @@ extension Process {
         if let terminationError = process.terminationError {
           continuation.resume(throwing: terminationError)
         } else {
-          stdOut.yieldValue { data in
+          stdOut.yieldValueAndClose { data in
             continuation.resume(returning: data)
           }
         }

--- a/Sources/Sh/Process/Process.runReturningData.swift
+++ b/Sources/Sh/Process/Process.runReturningData.swift
@@ -15,7 +15,7 @@ extension Process {
     if let terminationError = terminationError {
       throw terminationError
     } else {
-      return stdOut.closeReturningData()
+      return try stdOut.closeReturningData()
     }
   }
     
@@ -30,8 +30,12 @@ extension Process {
         if let terminationError = process.terminationError {
           continuation.resume(throwing: terminationError)
         } else {
-          let data = stdOut.closeReturningData()
-          continuation.resume(returning: data)
+          do {
+            let data = try stdOut.closeReturningData()
+            continuation.resume(returning: data)
+          } catch {
+            continuation.resume(throwing: error)
+          }
         }
       }
       

--- a/Sources/Sh/sh.swift
+++ b/Sources/Sh/sh.swift
@@ -107,8 +107,11 @@ public func sh(_ sink: Sink,
       let underlyingError = error
 
       let logResult = Result {
-        let lastFewLines = try sh("tail -n 10 \(path)")?
-          .trimmingCharacters(in: .whitespacesAndNewlines) ?? "<no content in log file>"
+
+        guard let lastFewLines = try sh("tail -n 10 \(path)")?
+          .trimmingCharacters(in: .whitespacesAndNewlines), !lastFewLines.isEmpty else {
+          return "<no content in log file>"
+        }
 
         return lastFewLines
       }

--- a/Sources/Sh/sh.swift
+++ b/Sources/Sh/sh.swift
@@ -107,8 +107,10 @@ public func sh(_ sink: Sink,
       let underlyingError = error
 
       let logResult = Result {
-        try String(contentsOfFile: path)
-          .trimmingCharacters(in: .whitespacesAndNewlines)
+        let lastFewLines = try sh("tail -n 10 \(path)")?
+          .trimmingCharacters(in: .whitespacesAndNewlines) ?? "<no content in log file>"
+
+        return lastFewLines
       }
 
       switch logResult {

--- a/Sources/Sh/shq.swift
+++ b/Sources/Sh/shq.swift
@@ -57,12 +57,13 @@ public func shq<D: Decodable>(_ type: D.Type,
                               decodedBy jsonDecoder: JSONDecoder = .init(),
                               _ cmd: String,
                              environment: [String: String] = [:],
-                             workingDirectory: String? = nil) async throws -> D {
-  try await Process(cmd: cmd,
-                    environment: environment,
-                    workingDirectory: workingDirectory)
-  .runReturningData()
-  .asJSON(decoding: type, using: jsonDecoder)
+                              workingDirectory: String? = nil) async throws -> D {
+  let data = try await Process(
+    cmd: cmd,
+    environment: environment,
+    workingDirectory: workingDirectory)
+    .runReturningData()
+  return try data.asJSON(decoding: type, using: jsonDecoder)
 }
 
 /// Run a shell command, sending output to the terminal or a file.

--- a/Tests/ShTests/AsyncDecodingTests.swift
+++ b/Tests/ShTests/AsyncDecodingTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+@testable import Sh
+
+final class AsyncDecodingTests: XCTestCase {
+  func testCustomDecodeJsonOutputAsync() async throws {
+    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
+
+    struct Event: Decodable {
+      let type: String
+      let date: Date
+    }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
+    XCTAssertEqual(events.count, 2)
+    XCTAssertEqual(events.first?.type, "start")
+    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
+    XCTAssertEqual(events.last?.type, "stop")
+    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
+  }
+}

--- a/Tests/ShTests/AsyncTests.swift
+++ b/Tests/ShTests/AsyncTests.swift
@@ -33,7 +33,7 @@ final class AsyncTests: XCTestCase {
 
   func testPrintingErrorWhenFileOutputIsLong() throws {
     do {
-      try sh(.file("/tmp/sh-test.log"), """
+      try sh(.file("/tmp/sh-AsyncTests.testPrintingErrorWhenFileOutputIsLong.log"), """
       swift test --package-path Fixtures/SwiftProjectWithFailingTests
       """)
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")

--- a/Tests/ShTests/AsyncTests.swift
+++ b/Tests/ShTests/AsyncTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+@testable import Sh
+
+// These are having issues running in the full suite of tests?
+
+final class AsyncTests: XCTestCase {
+
+  func testSimpleAsync() async throws {
+    let process = Process(cmd: #"echo simple"#)
+    let allOutput = try await process.runReturningAllOutput()
+
+    XCTAssertEqual(allOutput.stdOut.asTrimmedString(), "simple")
+    XCTAssertEqual(allOutput.stdErr, Data())
+    XCTAssertNil(allOutput.terminationError)
+  }
+
+  func testCustomDecodeJsonOutputAsync() async throws {
+    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
+
+    struct Event: Decodable {
+      let type: String
+      let date: Date
+    }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
+    XCTAssertEqual(events.count, 2)
+    XCTAssertEqual(events.first?.type, "start")
+    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
+    XCTAssertEqual(events.last?.type, "stop")
+    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
+  }
+}

--- a/Tests/ShTests/AsyncTests.swift
+++ b/Tests/ShTests/AsyncTests.swift
@@ -44,7 +44,7 @@ final class AsyncTests: XCTestCase {
       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
 
       XCTAssertNotEqual(terminationError.status, 0)
-      XCTAssertEqual(terminationError.reason, "`regular exit`")
+      XCTAssertEqual(terminationError.reason, .exit)
 
       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
       XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))

--- a/Tests/ShTests/AsyncTests.swift
+++ b/Tests/ShTests/AsyncTests.swift
@@ -13,24 +13,6 @@ final class AsyncTests: XCTestCase {
     XCTAssertNil(allOutput.terminationError)
   }
 
-  func testCustomDecodeJsonOutputAsync() async throws {
-    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
-
-    struct Event: Decodable {
-      let type: String
-      let date: Date
-    }
-
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
-    XCTAssertEqual(events.count, 2)
-    XCTAssertEqual(events.first?.type, "start")
-    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
-    XCTAssertEqual(events.last?.type, "stop")
-    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
-  }
-
   func testPrintingErrorWhenFileOutputIsLong() throws {
     do {
       try sh(.file("/tmp/sh-AsyncTests.testPrintingErrorWhenFileOutputIsLong.log"), """

--- a/Tests/ShTests/AsyncTests.swift
+++ b/Tests/ShTests/AsyncTests.swift
@@ -13,11 +13,11 @@ final class AsyncTests: XCTestCase {
     XCTAssertNil(allOutput.terminationError)
   }
 
-  func testPrintingErrorWhenFileOutputIsLong() throws {
+  func testPrintingErrorWhenFileOutputIsLongAsync() async throws {
     do {
-      try sh(.file("/tmp/sh-AsyncTests.testPrintingErrorWhenFileOutputIsLong.log"), """
-      swift test --package-path Fixtures/SwiftProjectWithFailingTests
-      """)
+      try await sh(.file("/tmp/sh-AsyncTests.testPrintingErrorWhenFileOutputIsLong.log"),
+                   "swift test --package-path Fixtures/SwiftProjectWithFailingTests")
+      
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -37,6 +37,28 @@ final class LogFileTests: XCTestCase {
     }
   }
   
+  func testPrintingErrorWhenFileOutputIsLong() throws {
+    do {
+      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsLong.log"), """
+      swift test --package-path Fixtures/SwiftProjectWithFailingTests
+      """)
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
+    } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
+
+      XCTAssertTrue(logInfo.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
+
+      let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
+
+      XCTAssertNotEqual(terminationError.status, 0)
+      XCTAssertEqual(terminationError.reason, .exit)
+
+      let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
+      XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
+    } catch {
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
+    }
+  }
+
   func testCreatesMissingLogfiles() throws {
     
     do {

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -6,12 +6,12 @@ final class LogFileTests: XCTestCase {
 
   func testSimple() throws {
     try sh(.file("/tmp/sh-LogFileTests.testSimple.log"), #"echo "simple""#)
-    XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
+    XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimple.log"), "simple\n")
   }
 
   func testSimpleAsync() async throws {
     try await sh(.file("/tmp/sh-LogFileTests.testSimpleAsync.log"), #"echo "simple""#)
-    XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
+    XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimpleAsync.log"), "simple\n")
   }
 
    func testPrintingErrorWhenFileOutputIsShort() throws {

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -25,7 +25,7 @@ final class LogFileTests: XCTestCase {
        let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
 
        XCTAssertNotEqual(terminationError.status, 0)
-       XCTAssertEqual(terminationError.reason, "`regular exit`")
+       XCTAssertEqual(terminationError.reason, .exit)
 
        let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
        XCTAssertTrue(error.localizedDescription.contains("/unknown/path/name"))
@@ -47,7 +47,7 @@ final class LogFileTests: XCTestCase {
       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
 
       XCTAssertNotEqual(terminationError.status, 0)
-      XCTAssertEqual(terminationError.reason, "`regular exit`")
+      XCTAssertEqual(terminationError.reason, .exit)
 
       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
       XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
@@ -63,7 +63,7 @@ final class LogFileTests: XCTestCase {
       try sh(.file("/tmp/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
       XCTAssertEqual(info, "/bin/sh: /unknown/path/name: No such file or directory")
-      XCTAssertEqual(underlyingError.localizedDescription, "Ended with status 1 with reason: `regular exit`")
+      XCTAssertEqual(underlyingError.localizedDescription, "Exited with code 1.")
     } catch {
       XCTFail("Expected an errorWithLogInfo, but got \(error)")
     }
@@ -74,7 +74,7 @@ final class LogFileTests: XCTestCase {
       try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
 
-      XCTAssertEqual(logError.localizedDescription, "Ended with status 1 with reason: `regular exit`")
+      XCTAssertEqual(logError.localizedDescription, "Exited with code 1.")
       XCTAssertEqual(underlyingError.localizedDescription, "You can’t save the file “path” because the volume is read only.")
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -14,36 +14,48 @@ final class LogFileTests: XCTestCase {
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
   }
 
-//   func testPrintingErrorWhenFileOutputIsShort() throws {
-//     do {
-//       try sh(.file("/tmp/sh-test.log"), """
-//       swift test --package-path Fixtures/SwiftProjectWithFailingTests
-//       """)
-//       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
-//     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
-//
-//       XCTAssertTrue(logInfo.contains("/unknown/path/name"))
-//
-//       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
-//
-//       XCTAssertNotEqual(terminationError.status, 0)
-//       XCTAssertEqual(terminationError.reason, "`regular exit`")
-//
-//
-//       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
-//       XCTAssertEqual(error.localizedDescription, """
-//       An error occurred: Ended with status 1 with reason: `regular exit`. Here is the contents of the log file:
-//
-//       /bin/sh: /unknown/path/name: No such file or directory
-//       """)
-//
-//     } catch {
-//       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
-//     }
-//   }
+   func testPrintingErrorWhenFileOutputIsShort() throws {
+     do {
+       try sh(.file("/tmp/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
+     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
+
+       XCTAssertTrue(logInfo.contains("/unknown/path/name"))
+
+       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
+
+       XCTAssertNotEqual(terminationError.status, 0)
+       XCTAssertEqual(terminationError.reason, "`regular exit`")
+
+       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
+       XCTAssertTrue(error.localizedDescription.contains("/unknown/path/name"))
+     } catch {
+       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
+     }
+   }
 
   func testPrintingErrorWhenFileOutputIsLong() throws {
+    do {
+      try sh(.file("/tmp/sh-test.log"), """
+      swift test --package-path Fixtures/SwiftProjectWithFailingTests
+      """)
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
+    } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 
+      XCTAssertTrue(logInfo.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
+
+      let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
+
+      XCTAssertNotEqual(terminationError.status, 0)
+      XCTAssertEqual(terminationError.reason, "`regular exit`")
+
+      let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
+      XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
+
+//      print(error.localizedDescription)
+    } catch {
+      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
+    }
   }
 
   func testUnwritableLogfile() throws {

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -5,18 +5,21 @@ import Foundation
 final class LogFileTests: XCTestCase {
 
   func testSimple() throws {
-    try sh(.file("/tmp/sh-LogFileTests.testSimple.log"), #"echo "simple""#)
+    try sh(.file("/tmp/sh-LogFileTests.testSimple.log"),
+           #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimple.log"), "simple\n")
   }
 
   func testSimpleAsync() async throws {
-    try await sh(.file("/tmp/sh-LogFileTests.testSimpleAsync.log"), #"echo "simple""#)
+    try await sh(.file("/tmp/sh-LogFileTests.testSimpleAsync.log"),
+                 #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimpleAsync.log"), "simple\n")
   }
 
    func testPrintingErrorWhenFileOutputIsShort() throws {
      do {
-       try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsShort.log"), #"echo "simple" > /unknown/path/name"#)
+       try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsShort.log"),
+              #"echo "simple" > /unknown/path/name"#)
        XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
      } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 
@@ -36,9 +39,8 @@ final class LogFileTests: XCTestCase {
 
   func testPrintingErrorWhenFileOutputIsLong() throws {
     do {
-      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsLong.log"), """
-      swift test --package-path Fixtures/SwiftProjectWithFailingTests
-      """)
+      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsLong.log"),
+             "swift test --package-path Fixtures/SwiftProjectWithFailingTests")
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 
@@ -60,7 +62,8 @@ final class LogFileTests: XCTestCase {
   func testCreatesMissingLogfiles() throws {
 
     do {
-      try sh(.file("/tmp/missing/path/sh-testCreatesMissingLogfiles.log"), #"echo "simple" > /unknown/path/name"#)
+      try sh(.file("/tmp/missing/path/sh-testCreatesMissingLogfiles.log"),
+             #"echo "simple" > /unknown/path/name"#)
     } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
       #if os(Linux)
       XCTAssertEqual(info, "/bin/sh: 1: cannot create /unknown/path/name: Directory nonexistent")
@@ -76,7 +79,8 @@ final class LogFileTests: XCTestCase {
 
   func testUnwritableLogfile() throws {
     do {
-      try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+      try sh(.file("/missing/path/sh-test.log"),
+             #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
 
       XCTAssertEqual(logError.localizedDescription, "Exited with code 1.")

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -5,18 +5,18 @@ import Foundation
 final class LogFileTests: XCTestCase {
 
   func testSimple() throws {
-    try sh(.file("/tmp/sh-test.log"), #"echo "simple""#)
+    try sh(.file("/tmp/sh-LogFileTests.testSimple.log"), #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
   }
 
   func testSimpleAsync() async throws {
-    try await sh(.file("/tmp/sh-test.log"), #"echo "simple""#)
+    try await sh(.file("/tmp/sh-LogFileTests.testSimpleAsync.log"), #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
   }
 
    func testPrintingErrorWhenFileOutputIsShort() throws {
      do {
-       try sh(.file("/tmp/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+       try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsShort.log"), #"echo "simple" > /unknown/path/name"#)
        XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
      } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
 
@@ -36,7 +36,7 @@ final class LogFileTests: XCTestCase {
 
   func testPrintingErrorWhenFileOutputIsLong() throws {
     do {
-      try sh(.file("/tmp/sh-test.log"), """
+      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsLong.log"), """
       swift test --package-path Fixtures/SwiftProjectWithFailingTests
       """)
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
@@ -60,7 +60,7 @@ final class LogFileTests: XCTestCase {
   func testCreatesMissingLogfiles() throws {
 
     do {
-      try sh(.file("/tmp/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+      try sh(.file("/tmp/missing/path/sh-testCreatesMissingLogfiles.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
       #if os(Linux)
       XCTAssertEqual(info, "/bin/sh: 1: cannot create /unknown/path/name: Directory nonexistent")

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import Sh
 
 final class LogFileTests: XCTestCase {
-  
+
   func testSimple() throws {
     try sh(.file("/tmp/sh-test.log"), #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
@@ -14,23 +14,37 @@ final class LogFileTests: XCTestCase {
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-test.log"), "simple\n")
   }
 
-  func testError() throws {
-    do {
-      try sh(.file("/tmp/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
-      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
-    } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
+//   func testPrintingErrorWhenFileOutputIsShort() throws {
+//     do {
+//       try sh(.file("/tmp/sh-test.log"), """
+//       swift test --package-path Fixtures/SwiftProjectWithFailingTests
+//       """)
+//       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
+//     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
+//
+//       XCTAssertTrue(logInfo.contains("/unknown/path/name"))
+//
+//       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
+//
+//       XCTAssertNotEqual(terminationError.status, 0)
+//       XCTAssertEqual(terminationError.reason, "`regular exit`")
+//
+//
+//       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
+//       XCTAssertEqual(error.localizedDescription, """
+//       An error occurred: Ended with status 1 with reason: `regular exit`. Here is the contents of the log file:
+//
+//       /bin/sh: /unknown/path/name: No such file or directory
+//       """)
+//
+//     } catch {
+//       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
+//     }
+//   }
 
-      XCTAssertTrue(logInfo.contains("/unknown/path/name"))
+  func testPrintingErrorWhenFileOutputIsLong() throws {
 
-      let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
-
-      XCTAssertNotEqual(terminationError.status, 0)
-      XCTAssertEqual(terminationError.reason, "`regular exit`")
-    } catch {
-      XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
-    }
   }
-  
 
   func testUnwritableLogfile() throws {
     do {

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -62,8 +62,13 @@ final class LogFileTests: XCTestCase {
     do {
       try sh(.file("/tmp/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
+      #if os(Linux)
+      XCTAssertEqual(info, "/bin/sh: 1: cannot create /unknown/path/name: Directory nonexistent")
+      XCTAssertEqual(underlyingError.localizedDescription, "Exited with code 2.")
+      #else
       XCTAssertEqual(info, "/bin/sh: /unknown/path/name: No such file or directory")
       XCTAssertEqual(underlyingError.localizedDescription, "Exited with code 1.")
+      #endif
     } catch {
       XCTFail("Expected an errorWithLogInfo, but got \(error)")
     }
@@ -75,7 +80,11 @@ final class LogFileTests: XCTestCase {
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
 
       XCTAssertEqual(logError.localizedDescription, "Exited with code 1.")
+      #if os(Linux)
+      XCTAssertEqual(underlyingError.localizedDescription, "The operation could not be completed. You don’t have permission.")
+      #else
       XCTAssertEqual(underlyingError.localizedDescription, "You can’t save the file “path” because the volume is read only.")
+      #endif
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")
     }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -63,14 +63,8 @@ final class LogFileTests: XCTestCase {
       try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
 
-      #if os(Linux)
-      XCTAssertEqual(logError.localizedDescription, "The operation could not be completed. No such file or directory")
-      #else
-      XCTAssertEqual(logError.localizedDescription, "The file “sh-test.log” couldn’t be opened because there is no such file.")
-      #endif
-
+      XCTAssertEqual(logError.localizedDescription, "Ended with status 1 with reason: `regular exit`")
       XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
-
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")
     }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -52,7 +52,6 @@ final class LogFileTests: XCTestCase {
       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
       XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
 
-//      print(error.localizedDescription)
     } catch {
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
     }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -57,13 +57,25 @@ final class LogFileTests: XCTestCase {
     }
   }
 
+  func testCreatesMissingLogfiles() throws {
+
+    do {
+      try sh(.file("/tmp/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
+    } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
+      XCTAssertEqual(info, "/bin/sh: /unknown/path/name: No such file or directory")
+      XCTAssertEqual(underlyingError.localizedDescription, "Ended with status 1 with reason: `regular exit`")
+    } catch {
+      XCTFail("Expected an errorWithLogInfo, but got \(error)")
+    }
+  }
+
   func testUnwritableLogfile() throws {
     do {
       try sh(.file("/missing/path/sh-test.log"), #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
 
       XCTAssertEqual(logError.localizedDescription, "Ended with status 1 with reason: `regular exit`")
-      XCTAssertTrue(underlyingError.localizedDescription.contains("CouldNotCreateFile error"))
+      XCTAssertEqual(underlyingError.localizedDescription, "You can’t save the file “path” because the volume is read only.")
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")
     }

--- a/Tests/ShTests/LogFileTests.swift
+++ b/Tests/ShTests/LogFileTests.swift
@@ -3,92 +3,70 @@ import Foundation
 @testable import Sh
 
 final class LogFileTests: XCTestCase {
-
+  
   func testSimple() throws {
     try sh(.file("/tmp/sh-LogFileTests.testSimple.log"),
            #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimple.log"), "simple\n")
   }
-
+  
   func testSimpleAsync() async throws {
     try await sh(.file("/tmp/sh-LogFileTests.testSimpleAsync.log"),
                  #"echo "simple""#)
     XCTAssertEqual(try String(contentsOfFile: "/tmp/sh-LogFileTests.testSimpleAsync.log"), "simple\n")
   }
-
-   func testPrintingErrorWhenFileOutputIsShort() throws {
-     do {
-       try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsShort.log"),
-              #"echo "simple" > /unknown/path/name"#)
-       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
-     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
-
-       XCTAssertTrue(logInfo.contains("/unknown/path/name"))
-
-       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
-
-       XCTAssertNotEqual(terminationError.status, 0)
-       XCTAssertEqual(terminationError.reason, .exit)
-
-       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
-       XCTAssertTrue(error.localizedDescription.contains("/unknown/path/name"))
-     } catch {
-       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
-     }
-   }
-
-  func testPrintingErrorWhenFileOutputIsLong() throws {
+  
+  func testPrintingErrorWhenFileOutputIsShort() throws {
     do {
-      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsLong.log"),
-             "swift test --package-path Fixtures/SwiftProjectWithFailingTests")
+      try sh(.file("/tmp/sh-LogFileTests.testPrintingErrorWhenFileOutputIsShort.log"),
+             #"echo "simple" > /unknown/path/name"#)
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`")
     } catch Errors.errorWithLogInfo(let logInfo, underlyingError: let underlyingError) {
-
-      XCTAssertTrue(logInfo.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
-
+      
+      XCTAssertTrue(logInfo.contains("/unknown/path/name"))
+      
       let terminationError = try XCTUnwrap(underlyingError as? TerminationError)
-
+      
       XCTAssertNotEqual(terminationError.status, 0)
       XCTAssertEqual(terminationError.reason, .exit)
-
+      
       let error = Errors.errorWithLogInfo(logInfo, underlyingError: underlyingError)
-      XCTAssertTrue(error.localizedDescription.contains(#"XCTAssertEqual failed: ("Some name") is not equal to ("Wrong name")"#))
-
+      XCTAssertTrue(error.localizedDescription.contains("/unknown/path/name"))
     } catch {
       XCTFail("Expected the above to throw an `Errors.errorWithLogInfo`, instead got an \(error)")
     }
   }
-
+  
   func testCreatesMissingLogfiles() throws {
-
+    
     do {
       try sh(.file("/tmp/missing/path/sh-testCreatesMissingLogfiles.log"),
              #"echo "simple" > /unknown/path/name"#)
     } catch Errors.errorWithLogInfo(let info, underlyingError: let underlyingError) {
-      #if os(Linux)
+#if os(Linux)
       XCTAssertEqual(info, "/bin/sh: 1: cannot create /unknown/path/name: Directory nonexistent")
       XCTAssertEqual(underlyingError.localizedDescription, "Exited with code 2.")
-      #else
+#else
       XCTAssertEqual(info, "/bin/sh: /unknown/path/name: No such file or directory")
       XCTAssertEqual(underlyingError.localizedDescription, "Exited with code 1.")
-      #endif
+#endif
     } catch {
       XCTFail("Expected an errorWithLogInfo, but got \(error)")
     }
   }
-
+  
   func testUnwritableLogfile() throws {
     do {
       try sh(.file("/missing/path/sh-test.log"),
              #"echo "simple" > /unknown/path/name"#)
     } catch Errors.openingLogError(let logError, underlyingError: let underlyingError) {
-
+      
       XCTAssertEqual(logError.localizedDescription, "Exited with code 1.")
-      #if os(Linux)
+#if os(Linux)
       XCTAssertEqual(underlyingError.localizedDescription, "The operation could not be completed. You don’t have permission.")
-      #else
+#else
       XCTAssertEqual(underlyingError.localizedDescription, "You can’t save the file “path” because the volume is read only.")
-      #endif
+#endif
     } catch {
       XCTFail("Expected an opening log error, but got \(error)")
     }

--- a/Tests/ShTests/ReturningAllOutputTests.swift
+++ b/Tests/ShTests/ReturningAllOutputTests.swift
@@ -14,7 +14,7 @@ final class ReturningAllOutputTests: XCTestCase {
   }
   
   func testSimpleAsync() async throws {
-    let process = Process(cmd: #"echo "simple""#)
+    let process = Process(cmd: #"echo simple"#)
     let allOutput = try await process.runReturningAllOutput()
     
     XCTAssertEqual(allOutput.stdOut.asTrimmedString(), "simple")

--- a/Tests/ShTests/ReturningAllOutputTests.swift
+++ b/Tests/ShTests/ReturningAllOutputTests.swift
@@ -12,16 +12,7 @@ final class ReturningAllOutputTests: XCTestCase {
     XCTAssertEqual(allOutput.stdErr, Data())
     XCTAssertNil(allOutput.terminationError)
   }
-  
-  func testSimpleAsync() async throws {
-    let process = Process(cmd: #"echo simple"#)
-    let allOutput = try await process.runReturningAllOutput()
-    
-    XCTAssertEqual(allOutput.stdOut.asTrimmedString(), "simple")
-    XCTAssertEqual(allOutput.stdErr, Data())
-    XCTAssertNil(allOutput.terminationError)
-  }
-  
+   
   func testLoremIpsumData() throws {
     let cmd = #"echo "$LOREM_IPSUM""#
     let environment = ["LOREM_IPSUM": loremIpsum!]

--- a/Tests/ShTests/ReturningAllOutputTests.swift
+++ b/Tests/ShTests/ReturningAllOutputTests.swift
@@ -24,7 +24,7 @@ final class ReturningAllOutputTests: XCTestCase {
   
   func testLoremIpsumData() throws {
     let cmd = #"echo "$LOREM_IPSUM""#
-    let environment = ["LOREM_IPSUM": loremIpsum]
+    let environment = ["LOREM_IPSUM": loremIpsum!]
     let output = try sh(cmd, environment: environment)
     XCTAssertEqual(output, loremIpsum)
   }
@@ -47,8 +47,14 @@ final class ReturningAllOutputTests: XCTestCase {
     XCTAssertEqual(allOutput.stdErr, Data())
     XCTAssertNil(allOutput.terminationError)
   }
-  
-  private let loremIpsum = """
+
+
+  private var loremIpsum: String!
+  override func tearDown() {
+    loremIpsum = nil
+  }
+  override func setUp() {
+    loremIpsum = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id pretium ex. Aliquam rhoncus libero dolor, ut egestas mauris auctor ut. Curabitur accumsan pharetra sagittis. Aliquam neque elit, venenatis ac luctus id, bibendum vel arcu. Nulla sollicitudin bibendum tincidunt. Vestibulum lectus sapien, facilisis a bibendum viverra, ullamcorper scelerisque leo. Proin mollis commodo orci at accumsan. Aenean nisl ex, iaculis tincidunt eros quis, consequat auctor nisl. Integer nec felis egestas erat posuere aliquam. Praesent commodo nibh rutrum, eleifend sem vitae, molestie est. Aenean eleifend ipsum vel tellus fermentum mattis.
 
 Phasellus mollis ut enim id pellentesque. Proin congue est feugiat odio vestibulum volutpat. In varius aliquam sapien eu iaculis. Phasellus vitae mauris sit amet massa euismod dictum vel in metus. Morbi ut orci et libero cursus consequat vitae vel eros. Donec accumsan dolor sit amet tincidunt porta. Sed bibendum risus at justo euismod, ut rhoncus urna molestie. Praesent at congue odio, vitae consequat leo. Etiam vel cursus leo, ac fringilla lacus. Duis ac tempus ante. Donec vel elementum mi, ut lobortis enim.
@@ -77,4 +83,5 @@ Aliquam erat volutpat. Sed commodo ligula non nunc pulvinar, vel pretium velit p
 
 Pellentesque scelerisque, purus vitae suscipit consectetur, diam lacus ultricies ex, vehicula lobortis ligula ipsum ut magna. Nulla blandit egestas massa non ultricies. In purus lorem, volutpat ac efficitur ac, vehicula quis felis. Suspendisse potenti. Praesent suscipit, ipsum vel varius vulputate, felis sem mattis ex, vitae aliquet massa felis ut nibh. Integer id arcu arcu. Ut pulvinar ipsum in ipsum tempor, sit amet iaculis risus commodo. Suspendisse euismod mi a elementum tincidunt. Quisque id dapibus sem. Nam hendrerit arcu ut auctor cursus. Mauris condimentum mi non malesuada viverra. Vivamus dictum sed nulla dapibus vehicula. Ut facilisis augue nunc, nec commodo ante ullamcorper id. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed pharetra turpis nec urna suscipit volutpat.
 """.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
 }

--- a/Tests/ShTests/ReturningOutputTests.swift
+++ b/Tests/ShTests/ReturningOutputTests.swift
@@ -53,16 +53,16 @@ final class ReturningOutputTests: XCTestCase {
   }
   
   func testCustomDecodeJsonOutputAsync() async throws {
-    let json = #"[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]"#
+    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
     
-    struct Event: Codable {
+    struct Event: Decodable {
       let type: String
       let date: Date
     }
     
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    let events = try await sh([Event].self, decodedBy: decoder, "echo '\(json)'")
+    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
     XCTAssertEqual(events.count, 2)
     XCTAssertEqual(events.first?.type, "start")
     XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)

--- a/Tests/ShTests/ReturningOutputTests.swift
+++ b/Tests/ShTests/ReturningOutputTests.swift
@@ -52,23 +52,7 @@ final class ReturningOutputTests: XCTestCase {
     XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
   }
   
-  func testCustomDecodeJsonOutputAsync() async throws {
-    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
-    
-    struct Event: Decodable {
-      let type: String
-      let date: Date
-    }
-    
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
-    XCTAssertEqual(events.count, 2)
-    XCTAssertEqual(events.first?.type, "start")
-    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
-    XCTAssertEqual(events.last?.type, "stop")
-    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
-  }
+
 
   func testNilOrEmptyOutputThrowsErrorWhenDecoding() {
     do {
@@ -83,5 +67,23 @@ final class ReturningOutputTests: XCTestCase {
   func testDecodingStringOutput() throws {
     XCTAssertEqual(1, try sh(Int.self, "echo 1"))
     XCTAssertEqual(Date().timeIntervalSince1970, try sh(TimeInterval.self, "date +%s"), accuracy: 1)
+  }
+
+  func testCustomDecodeJsonOutputAsync() async throws {
+    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
+
+    struct Event: Decodable {
+      let type: String
+      let date: Date
+    }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
+    XCTAssertEqual(events.count, 2)
+    XCTAssertEqual(events.first?.type, "start")
+    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
+    XCTAssertEqual(events.last?.type, "stop")
+    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
   }
 }

--- a/Tests/ShTests/ReturningOutputTests.swift
+++ b/Tests/ShTests/ReturningOutputTests.swift
@@ -34,26 +34,6 @@ final class ReturningOutputTests: XCTestCase {
     XCTAssertEqual(gasses.last?.color, .clear)
   }
   
-  func testCustomDecodeJsonOutput() throws {
-    let json = #"[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date": "2023-10-29T19:22:22Z"}]"#
-    
-    struct Event: Codable {
-      let type: String
-      let date: Date
-    }
-    
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    let events = try sh([Event].self, decodedBy: decoder, "echo '\(json)'")
-    XCTAssertEqual(events.count, 2)
-    XCTAssertEqual(events.first?.type, "start")
-    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
-    XCTAssertEqual(events.last?.type, "stop")
-    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
-  }
-  
-
-
   func testNilOrEmptyOutputThrowsErrorWhenDecoding() {
     do {
       let _ = try sh([Int].self, "echo")

--- a/Tests/ShTests/ReturningOutputTests.swift
+++ b/Tests/ShTests/ReturningOutputTests.swift
@@ -68,22 +68,4 @@ final class ReturningOutputTests: XCTestCase {
     XCTAssertEqual(1, try sh(Int.self, "echo 1"))
     XCTAssertEqual(Date().timeIntervalSince1970, try sh(TimeInterval.self, "date +%s"), accuracy: 1)
   }
-
-  func testCustomDecodeJsonOutputAsync() async throws {
-    let json = #"'[{"type":"start","date":"2022-10-29T19:22:22Z"},{"type":"stop","date":"2023-10-29T19:22:22Z"}]'"#
-
-    struct Event: Decodable {
-      let type: String
-      let date: Date
-    }
-
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    let events = try await sh([Event].self, decodedBy: decoder, "echo \(json)")
-    XCTAssertEqual(events.count, 2)
-    XCTAssertEqual(events.first?.type, "start")
-    XCTAssertEqual(events.first?.date.timeIntervalSince1970, 1667071342)
-    XCTAssertEqual(events.last?.type, "stop")
-    XCTAssertEqual(events.last?.date.timeIntervalSince1970, 1698607342)
-  }
 }


### PR DESCRIPTION
**Swift 5.8 & macOS 13**
Couldn't get the tests to pass consistently on Swift 5.7 & macOS 12. Matrix testing now includes both macOS-13 

**Long log files fix**
Now only show last 10 lines of error log instead of whole file. Added a test for long output:A Swift package with an intentionally failing test so that we can test the error output of long out in Sh.

**Reference fix**
When getting the output from stdOut or stdErr, the reference to the private queue might not be garbage collected. Fix the references so that it can be. And appending data always uses the synchronization queue

**Automatically create log files**
And the directories that contain them. This simplifies writing output to a log file because you don't create the intermediate directories any more

**Async Tests**
Are moved to their own test file. When run as part of the regular suite, they failed ~50% of the time.



